### PR TITLE
Pre & post validation. Exceptions to http errors. Logging.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,8 @@
                  [ring/ring-core "1.7.1"]
                  [ring/ring-defaults "0.3.2"]
                  [ring/ring-json "0.4.0"]
-                 [selmer "1.12.5"]]
+                 [selmer "1.12.5"]
+                 [org.clojure/tools.logging "0.4.1"]]
 
   :min-lein-version "2.0.0"
 

--- a/src/clj/jobtech_taxonomy_api/db/core.clj
+++ b/src/clj/jobtech_taxonomy_api/db/core.clj
@@ -1,11 +1,12 @@
 (ns jobtech-taxonomy-api.db.core
   (:require
    [datomic.client.api :as d]
+   [schema.core :as s]
+   [clojure.test :refer [is]]
    [mount.core :refer [defstate]]
    [jobtech-taxonomy-api.config :refer [env]]
    [jobtech-taxonomy-api.nano-id :refer :all]
-   [jobtech-taxonomy-api.db.events :refer :all]
-   ))
+   [jobtech-taxonomy-api.db.events :refer :all]))
 
 #_(defstate conn
     :start (-> env :database-url d/connect)
@@ -16,12 +17,10 @@
 (defstate ^{:on-reload :noop} conn
   :start (d/connect (get-client)  {:db-name (:datomic-name env)}))
 
-
 (defn get-db [] (d/db conn))
 
 (defn get-conn "" []
   (d/connect (get-client)  {:db-name (:datomic-name env)}))
-
 
 (def find-concept-by-preferred-term-query
   '[:find (pull ?c
@@ -33,7 +32,16 @@
     :where [?t :term/base-form ?term]
     [?c :concept/preferred-term ?t]])
 
+(def find-concept-by-preferred-term-schema
+  "The response schema for the query below."
+  [[{:concept/id s/Str
+     :concept/description s/Str
+     :concept/preferred-term {:term/base-form s/Str}
+     (s/optional-key :concept/referring-terms) {:term/base-form s/Str}}]])
+
 (defn find-concept-by-preferred-term [term]
+  {:pre  [(is (and (not (nil? term)) (> (count term) 0))  "supply a non-empty string argument")]
+   :post [(is (not (empty? %)) "no such term")]}
   (d/q find-concept-by-preferred-term-query (get-db) term))
 
 (def find-concept-by-id-query
@@ -50,28 +58,23 @@
 
 (defn retract-concept [id]
   (let [retract (d/transact (get-conn) {:tx-data
-                                        [
-                                         {:concept/id id
-                                          :concept/deprecated true
-                                          }
-                                         ] })]
-    { :msg (if retract "ok" "bad") }))
+                                        [{:concept/id id
+                                          :concept/deprecated true}]})]
+
+    {:msg (if retract "ok" "bad")}))
 
 
 
 ;; TODO appeda pa replaced by listan
+
+
 (defn replace-deprecated-concept [old-concept-id new-concept-id]
   (let [data {:concept/id old-concept-id
-              :concept/replaced-by [{:concept/id new-concept-id}]
-              }
+              :concept/replaced-by [{:concept/id new-concept-id}]}
         result (d/transact (get-conn) {:tx-data [data]})
-        timestamp (nth (first (:tx-data result)) 2 )
-        ]
+        timestamp (nth (first (:tx-data result)) 2)]
 
-    { :msg (if result {:timestamp timestamp :status "OK"} {:status "ERROR"} ) }
-    )
-  )
-
+    {:msg (if result {:timestamp timestamp :status "OK"} {:status "ERROR"})}))
 
 (defn assert-concept-part [type desc pref-term]
   (let* [temp-id   (format "%s-%s-%s" type desc pref-term)
@@ -83,140 +86,138 @@
                      :concept/preferred-term temp-id
                      :concept/alternative-terms #{temp-id}}]
          result     (d/transact (get-conn) {:tx-data (vec (concat tx))})]
-    result)
-  )
-
+        result))
 
 (defn assert-concept "" [type desc pref-term]
   (let [result (assert-concept-part type desc pref-term)
-        timestamp (nth (first (:tx-data result)) 2 )
-        ]
+        timestamp (nth (first (:tx-data result)) 2)]
 
-    { :msg (if result {:timestamp timestamp :status "OK"} {:status "ERROR"} ) }))
-
-
-
+    {:msg (if result {:timestamp timestamp :status "OK"} {:status "ERROR"})}))
 
 (def get-concepts-for-type-query
-'[:find (pull ?c
-[:concept/id
- :concept/description
- :concept/category
- {:concept/preferred-term [:term/base-form]}
- {:concept/referring-terms [:term/base-form]}])
-:in $ ?type
-:where [?c :concept/category ?type]])
+  '[:find (pull ?c
+                [:concept/id
+                 :concept/description
+                 :concept/category
+                 {:concept/preferred-term [:term/base-form]}
+                 {:concept/referring-terms [:term/base-form]}])
+    :in $ ?type
+    :where [?c :concept/category ?type]])
 
 (defn get-concepts-for-type [type]
-(d/q get-concepts-for-type-query (get-db) (keyword type)))
+  (d/q get-concepts-for-type-query (get-db) (keyword type)))
 
 (def get-all-taxonomy-types-query
-'[:find ?v :where [_ :concept/category ?v]])
+  '[:find ?v :where [_ :concept/category ?v]])
 
 (defn get-all-taxonomy-types "" []
-(->> (d/q get-all-taxonomy-types-query (get-db))
-(sort-by first)))
+  (->> (d/q get-all-taxonomy-types-query (get-db))
+       (sort-by first)))
 
 (def show-term-history-query
-'[:find ?e ?aname ?v ?tx ?added
-:where
-[?e ?a ?v ?tx ?added]
-[?a :db/ident ?aname]])
+  '[:find ?e ?aname ?v ?tx ?added
+    :where
+    [?e ?a ?v ?tx ?added]
+    [?a :db/ident ?aname]])
 
 (defn ^:private format-result [result-list]
-(->> result-list
-(sort-by first)
-(partition-by #(let [[entity col value tx is-added] %] entity)) ; group by entity for better readability
+  (->> result-list
+       (sort-by first)
+       (partition-by #(let [[entity col value tx is-added] %] entity)) ; group by entity for better readability
 ;; The rest is for placing the result vectors into neat,
 ;; self-explanatory hashmaps - suitable for jsonifying later
-(map (fn [entity-group]
-       (map (fn [entity]
-              (let [[ent col value tx is-added] entity]
-                {:entity ent :col col :value value :tx tx :op (if is-added 'add 'retract)}))
-            entity-group)))))
+       (map (fn [entity-group]
+              (map (fn [entity]
+                     (let [[ent col value tx is-added] entity]
+                       {:entity ent :col col :value value :tx tx :op (if is-added 'add 'retract)}))
+                   entity-group)))))
 
 (defn ^:private show-term-history-back [q db]
-(->>
-(d/q q db)
-(format-result)))
+  (->>
+   (d/q q db)
+   (format-result)))
 
 (defn show-term-history []
   (show-term-history-back show-term-history-query (d/history (get-db))))
 
+(def show-concept-events-schema
+  "The response schema for the query below."
+  [{:event-type s/Str
+    :transaction-id s/Int
+    :timestamp java.util.Date
+    :concept-id s/Str
+    :preferred-term s/Str}])
+
 (defn show-concept-events []
-  (get-all-events (get-db))
-  )
+  (get-all-events (get-db)))
 
 (defn show-concept-events-since [date-time]
-  (get-all-events-since (get-db) date-time)
-  )
+  (get-all-events-since (get-db) date-time))
 
 (defn show-deprecated-concepts-and-replaced-by [date-time]
-  (get-deprecated-concepts-replaced-by-since (get-db) date-time)
-  )
-
+  (get-deprecated-concepts-replaced-by-since (get-db) date-time))
 
 (def show-term-history-since-query
-'[:find ?e ?aname ?v ?tx ?added
-:in $ ?since
-:where
-[?e  ?a ?v ?tx ?added]
-[?a  :db/ident ?aname]
-[?tx :db/txInstant ?created-at]
-[(< ?since ?created-at)]])
+  '[:find ?e ?aname ?v ?tx ?added
+    :in $ ?since
+    :where
+    [?e  ?a ?v ?tx ?added]
+    [?a  :db/ident ?aname]
+    [?tx :db/txInstant ?created-at]
+    [(< ?since ?created-at)]])
 
 (defn show-term-history-since [date-time]
-(->>
-(d/q show-term-history-since-query
-(get-db)
-date-time)
-(format-result)))
+  (->>
+   (d/q show-term-history-since-query
+        (get-db)
+        date-time)
+   (format-result)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;; DEBUG TOOLS ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn stupid-debug
-"The env/dev/resources/config.edn is not read when REPLing here, so
+  "The env/dev/resources/config.edn is not read when REPLing here, so
   we just make an ugly hack to be able to get on."
-[]
+  []
 
-(defn get-client [] (d/client {:server-type :peer-server
-                               :access-key  "myaccesskey"
-                               :secret      "mysecret"
-                               :endpoint    "localhost:8998"}))
+  (defn get-client [] (d/client {:server-type :peer-server
+                                 :access-key  "myaccesskey"
+                                 :secret      "mysecret"
+                                 :endpoint    "localhost:8998"}))
 
-(defn get-conn "" []
-(d/connect (get-client)  {:db-name "taxonomy_v13"}))
+  (defn get-conn "" []
+    (d/connect (get-client)  {:db-name "taxonomy_v13"}))
 
-(def conn (get-conn))
+  (def conn (get-conn))
 
-(defn get-db [] (d/db conn))
+  (defn get-db [] (d/db conn))
 
-(let [some-terms        [{:term/base-form "Kontaktmannaskap"}
-                         {:term/base-form "Fribrottare"}
-                         {:term/base-form "Begravningsentreprenör"}]
+  (let [some-terms        [{:term/base-form "Kontaktmannaskap"}
+                           {:term/base-form "Fribrottare"}
+                           {:term/base-form "Begravningsentreprenör"}]
 
-some-concepts     [{:concept/id "MZ6wMoAfyP"
-                    :concept/description "grotz"
-                    :concept/category :skill
-                    :concept/preferred-term [:term/base-form "Kontaktmannaskap"]
-                    :concept/alternative-terms #{[:term/base-form "Kontaktmannaskap"]}}
-                   {:concept/id "XYZYXYZYXYZ"
-                    :concept/description "Fribrottare"
-                    :concept/category :occupation
-                    :concept/preferred-term [:term/base-form "Fribrottare"]
-                    :concept/alternative-terms #{[:term/base-form "Fribrottare"]}}
-                   {:concept/id "ZZZZZZZZZZZ"
-                    :concept/description "Begravningsentreprenör"
-                    :concept/category :occupation
-                    :concept/preferred-term [:term/base-form "Begravningsentreprenör"]
-                    :concept/alternative-terms #{[:term/base-form "Begravningsentreprenör"]}}]]
-(d/transact (get-conn) {:tx-data (vec (concat some-terms))})
-(d/transact (get-conn) {:tx-data (vec (concat some-concepts))}))
+        some-concepts     [{:concept/id "MZ6wMoAfyP"
+                            :concept/description "grotz"
+                            :concept/category :skill
+                            :concept/preferred-term [:term/base-form "Kontaktmannaskap"]
+                            :concept/alternative-terms #{[:term/base-form "Kontaktmannaskap"]}}
+                           {:concept/id "XYZYXYZYXYZ"
+                            :concept/description "Fribrottare"
+                            :concept/category :occupation
+                            :concept/preferred-term [:term/base-form "Fribrottare"]
+                            :concept/alternative-terms #{[:term/base-form "Fribrottare"]}}
+                           {:concept/id "ZZZZZZZZZZZ"
+                            :concept/description "Begravningsentreprenör"
+                            :concept/category :occupation
+                            :concept/preferred-term [:term/base-form "Begravningsentreprenör"]
+                            :concept/alternative-terms #{[:term/base-form "Begravningsentreprenör"]}}]]
+    (d/transact (get-conn) {:tx-data (vec (concat some-terms))})
+    (d/transact (get-conn) {:tx-data (vec (concat some-concepts))}))
 
-(get-all-taxonomy-types)
-(get-concepts-for-type :occupation)
-(assert-concept "skill" "weqweqw" "fsdfsdfsd")
+  (get-all-taxonomy-types)
+  (get-concepts-for-type :occupation)
+  (assert-concept "skill" "weqweqw" "fsdfsdfsd")
 ;; (retract-concept "ZZZZZZZZZZZ")
-)
+  )
 ;; (stupid-debug)

--- a/src/clj/jobtech_taxonomy_api/routes/services.clj
+++ b/src/clj/jobtech_taxonomy_api/routes/services.clj
@@ -1,19 +1,30 @@
 (ns jobtech-taxonomy-api.routes.services
-  (:require [ring.util.http-response :refer :all]
-            [ring.middleware.json :refer [wrap-json-response]]
-            [compojure.api.sweet :refer :all]
-            [schema.core :as s]
-            [compojure.api.meta :refer [restructure-param]]
-            [buddy.auth.accessrules :refer [restrict]]
-            [buddy.auth :refer [authenticated?]]
-            [clojure.data.json :as json]
-            [clj-time [format :as f]]
-            [clj-time.coerce :as c]
-            [jobtech-taxonomy-api.db.core :refer :all]
-            ))
+  (:require
+   [ring.util.http-response :as response]
+   [ring.middleware.json :refer [wrap-json-response]]
+   [compojure.api.sweet :refer :all]
+   [schema.core :as s]
+   [compojure.api.meta :refer [restructure-param]]
+   [compojure.api.exception :as ex]
+   [buddy.auth.accessrules :refer [restrict]]
+   [buddy.auth :refer [authenticated?]]
+   [clojure.data.json :as json]
+   [clj-time [format :as f]]
+   [clj-time.coerce :as c]
+   [jobtech-taxonomy-api.db.core :refer :all]
+   [clojure.tools.logging :as log]))
+
+(import java.util.Date)
+
+(def date? (partial instance? Date))
+
+(def date-validator
+  {:message "must be a Date"
+   :optional true
+   :validate date?})
 
 (defn access-error [_ _]
-  (unauthorized {:error "unauthorized"}))
+  (response/unauthorized {:error "unauthorized"}))
 
 (defn wrap-restricted [handler rule]
   (restrict handler {:handler  rule
@@ -27,9 +38,20 @@
   [_ binding acc]
   (update-in acc [:letks] into [binding `(:identity ~'+compojure-api-request+)]))
 
+(defn custom-handler [f type]
+  (fn [^Exception e data request]
+    (log/log type (.getMessage e))
+    (f {:message (.getMessage e), :type type})))
+
 (def service-routes
   (api
-   {:swagger {:ui "/taxonomy/swagger-ui"
+   {:exceptions
+    {:handlers
+     {java.lang.AssertionError (custom-handler response/not-found :error)
+      java.lang.IllegalArgumentException (ex/with-logging ex/request-parsing-handler :error)
+      ::ex/default (custom-handler response/internal-server-error :unknown)}}
+
+    :swagger {:ui "/taxonomy/swagger-ui"
               :spec "/taxonomy/swagger.json"
               :data {:info {:version "1.0.0"
                             :title "Jobtech Taxonomy"
@@ -38,35 +60,33 @@
    (GET "/authenticated" []
      :auth-rules authenticated?
      :current-user user
-     (ok {:user user}))
+     (response/ok {:user user}))
 
    (context "/taxonomy/public-api" []
      :tags ["public"]
 
      (GET "/term" []
-
        :query-params [term :- String]
        :summary      "get term"
-       {:body (find-concept-by-preferred-term term)}
-       )
+       :return       find-concept-by-preferred-term-schema
+       {:body (find-concept-by-preferred-term term)})
 
      (GET "/full-history" []
        :query-params []
        :summary      "Show the complete history."
+       :return       show-concept-events-schema
        {:body (show-concept-events)})
 
      (GET "/concept-history-since" []
        :query-params [date-time :- String]
        :summary      "Show the history since the given date. Use the format '2017-06-09 14:30:01'."
+       :return       show-concept-events-schema
        {:body (show-concept-events-since (c/to-date (f/parse (f/formatter "yyyy-MM-dd HH:mm:ss") date-time)))})
 
      (GET "/deprecated-concept-history-since" []
        :query-params [date-time :- String]
        :summary      "Show the history since the given date. Use the format '2017-06-09 14:30:01'."
-       {:body (show-deprecated-concepts-and-replaced-by (c/to-date (f/parse (f/formatter "yyyy-MM-dd HH:mm:ss") date-time)))})
-
-
-     )
+       {:body (show-deprecated-concepts-and-replaced-by (c/to-date (f/parse (f/formatter "yyyy-MM-dd HH:mm:ss") date-time)))}))
 
    (context "/taxonomy/private-api" []
      :tags ["private"]
@@ -104,9 +124,6 @@
 
      (POST "/replace-concept"    []
        :query-params [old-concept-id :- String
-                      new-concept-id :- String
-                      ]
+                      new-concept-id :- String]
        :summary      "Replace old concept with a new concept."
-       {:body (replace-deprecated-concept old-concept-id new-concept-id)})
-
-     )))
+       {:body (replace-deprecated-concept old-concept-id new-concept-id)}))))


### PR DESCRIPTION
lein cljfmt fix har skapat en massa diffar som bara är omstuvning av whitespace.

* Swagger
Genom att specificera datatypen på returvärdet för en endpointoperation, så kan Swagger nu visa JSON-schemat för returvärden. Har bara lagt in det på tre endpoints i den publika gruppen än så länge. Datatypen anges med keywordet :return, så här:
```
(GET "/concept-history-since" []
       :query-params ...
       :summary      "..."
       :return       show-concept-events-schema
       {:body (show-concept-events-since (...
```
Jag placerade schemadefinitionerna i direkt anslutning till respektive funktion, i fallet ovan direkt i anslutning till definitionen av show-concept-events-since alltså.


* Datavalidering av input och output
Specialformerna :pre och :post:
```
(defn find-concept-by-preferred-term [term]
  {:pre  [(is (and (not (nil? term)) (> (count term) 0))  "supply a non-empty string argument")]
   :post [(is (not (empty? %)) "no such term")]}
  (d/q find-concept-by-preferred-term-query (get-db) term))
```
När en validering misslyckas så kastas ett java.lang.AssertionError. Detta fångar i services.clj och omvandlas till ett http-error:
```
(def service-routes
  (api
   {:exceptions
    {:handlers
     {java.lang.AssertionError (custom-handler response/not-found :error)
```
(response/not-found representerar 404).

* Loggning
Lade in en början till loggning i services.clj m h a clojure.tools.logging.
