### PR TITLE
Add endpoint GET /relation/graph/{relation-type}/{id}

### DIFF
--- a/src/clj/jobtech_taxonomy_api/db/core.clj
+++ b/src/clj/jobtech_taxonomy_api/db/core.clj
@@ -100,6 +100,19 @@
     [?c1 :concept/id ?c1id]
     [?c2 :concept/id ?c2id]])
 
+(def get-relation-graph-from-concept-query-rules
+  '[[(related-concepts ?c1 ?c2 ?t)
+     [?re :relation/type      ?t]
+     [?re :relation/concept-1 ?c1]
+     [?re :relation/concept-2 ?c2]]])
+
+(def get-relation-graph-from-concept-query
+  '[:find (pull ?child [:db/id
+                        :concept/id
+                        {:concept/preferred-term [:term/base-form]}])
+    :in $ % ?relation-type ?id :where
+    [?parent :concept/id ?id]
+    (related-concepts ?parent ?child ?relation-type)])
 
 (def map-id-to-term-query
   '[:find ?term
@@ -109,24 +122,12 @@
     [?ce :concept/preferred-term ?te]
     [?te :term/base-form ?term]])
 
-
-;; SLOW, memoryhungry - maybe because IDs are lost and overlapping occurs
-;; (def get-relation-graph-query
-;;   '[:find ?term1 ?term2
-;;     :in $ ?relation-type
-;;     :where
-;;     [?re :relation/type      ?relation-type]
-;;     [?re :relation/concept-1 ?c1]
-;;     [?re :relation/concept-2 ?c2]
-;;     [?c1 :concept/preferred-term ?c1tid]
-;;     [?c2 :concept/preferred-term ?c2tid]
-;;     [?c1tid :term/base-form ?term1]
-;;     [?c2tid :term/base-form ?term2]])
-
+; (find-concept-by-id "aqxj_t1i_SxL") ; Sydsudan
+; (find-concept-by-id "Gk4Z_5LP_v5G") ; Nordafrika
 
 (defn map-id-to-term [id]
-  (d/q map-id-to-term-query (get-db) id))
-
+  "Return the preferred label for a given ID. The query returns a list of lists, therefore we do an (ffirst)."
+  (ffirst (d/q map-id-to-term-query (get-db) id)))
 
 (defn get-relation-graph [relation-type]
   (letfn [(lazy-contains? [col key]
@@ -137,19 +138,21 @@
             (let [children (get-children parent all-pairs)
                   term (map-id-to-term parent)]
               (if (empty? children)
-                { "name" term, "size" 123 }
-                { "name" term, "children" (map #(get-hier-rec % all-pairs) children) })))]
+                { "name" term, "id" parent }
+                { "name" term, "id" parent, "children" (map #(get-hier-rec % all-pairs) children) })))]
     (let [list (d/q get-relation-graph-query (get-db) relation-type)
           map-key-val (map #(apply hash-map % ) list)
           map-val-key (map #(apply hash-map (reverse %) ) list)
           tops (->> (map #(first (keys %)) map-key-val)
                     (filter #(not (lazy-contains? map-val-key %)) ,,,)
                     (distinct ,,,))]
-      { "name" "Jobtech", "children" (map #(get-hier-rec % map-key-val) tops) })))
+      { "name" "Jobtech", "id" "666", "children" (map #(get-hier-rec % map-key-val) tops) })))
 
-
-;; (get-relation-graph :main-headline-to-headline)
-
+(defn get-relation-graph-from-concept [relation-type id]
+  (letfn [(format-answer [[list]]
+            { "name" (get-in list [:concept/preferred-term :term/base-form]) "id" (get-in list [:concept/id])})]
+    (let [lookup (d/q get-relation-graph-from-concept-query (get-db) get-relation-graph-from-concept-query-rules relation-type id)]
+      { "name" (map-id-to-term id), "id" id, "children" (map #(format-answer %) lookup) })))
 
 (def get-relation-types-query
   '[:find ?v :where [_ :relation/type ?v]])

--- a/src/clj/jobtech_taxonomy_api/routes/services.clj
+++ b/src/clj/jobtech_taxonomy_api/routes/services.clj
@@ -66,14 +66,25 @@
      :current-user user
      (response/ok {:user user}))
 
-   (GET "/relation/graph" []
-     :query-params [relation-type :- String]
-                    ; taxonomy :- String]
+   (GET "/relation/graph/:relation-type" []
+     :path-params [relation-type :- String]
      :responses {200 {:schema s/Any}
                  404 {:schema {:reason (s/enum :NOT_FOUND)}}
                  500 {:schema {:type s/Str, :message s/Str}}}
      :summary "Relation graphs."
      (let [result (get-relation-graph (keyword relation-type))] ; (keyword taxonomy)
+       (if (not-empty result)
+         (response/ok result)
+         (response/not-found {:reason :NOT_FOUND}))))
+
+   (GET "/relation/graph/:relation-type/:id" []
+     :path-params [relation-type :- String
+                   id :- String]
+     :responses {200 {:schema s/Any}
+                 404 {:schema {:reason (s/enum :NOT_FOUND)}}
+                 500 {:schema {:type s/Str, :message s/Str}}}
+     :summary "Relation graphs."
+     (let [result (get-relation-graph-from-concept (keyword relation-type) id)]
        (if (not-empty result)
          (response/ok result)
          (response/not-found {:reason :NOT_FOUND}))))


### PR DESCRIPTION
 - new endpoint for querying children of a given node and relation type.
 - trying out Datomic query rules (even though it was really trimmed down in the end, so it's almost unnecessary).
 - trying out path-params instead of query-params for size, what do you think?
