### PR TITLE
Fix bug allowing the same concept to be asserted twice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ then checks for its existence.
 
 First, require
 ```
-[jobtech-taxonomy-api.db.core :as core]
+[jobtech-taxonomy-api.db.concept :as c]
 
 ```
 
@@ -109,7 +109,7 @@ Then write a test:
 ```
 (test/deftest ^:concept-test-0 concept-test-0
   (test/testing "Test concept assertion."
-    (core/assert-concept "skill" "cykla" "cykla")
+    (c/assert-concept "skill" "cykla" "cykla")
     (let [found-concept (first (core/find-concept-by-preferred-term "cykla"))]
       (test/is (= "cykla" (get found-concept :preferredLabel))))))
 ```
@@ -120,7 +120,7 @@ then checks for its existence via the REST API:
 
 First, require
 ```
-[jobtech-taxonomy-api.db.core :as core]
+[jobtech-taxonomy-api.db.concept :as c]
 
 ```
 
@@ -128,7 +128,7 @@ Then write a test:
 ```
 (test/deftest ^:changes-test-1 changes-test-1
   (test/testing "test event stream"
-    (core/assert-concept "skill" "cykla" "cykla")
+    (c/assert-concept "skill" "cykla" "cykla")
     (let [[status body] (util/send-request-to-json-service
                          :get "/v0/taxonomy/public/concepts"
                          :headers [util/header-auth-user]

--- a/src/clj/jobtech_taxonomy_api/db/core.clj
+++ b/src/clj/jobtech_taxonomy_api/db/core.clj
@@ -171,24 +171,6 @@
 
     {:msg (if result {:timestamp timestamp :status "OK"} {:status "ERROR"})}))
 
-(defn assert-concept-part [type desc pref-term]
-  (let* [temp-id   (format "%s-%s-%s" type desc pref-term)
-         tx        [{:db/id temp-id
-                     :term/base-form pref-term}
-                    {:concept/id (nano/generate-new-id-with-underscore)
-                     :concept/description desc
-                     :concept/category (keyword (str type))
-                     :concept/preferred-term temp-id
-                     :concept/alternative-terms #{temp-id}}]
-         result     (d/transact (get-conn) {:tx-data (vec (concat tx))})]
-        result))
-
-(defn assert-concept "" [type desc pref-term]
-  (let [result (assert-concept-part type desc pref-term)
-        timestamp (nth (first (:tx-data result)) 2)]
-
-    {:msg (if result {:timestamp timestamp :status "OK"} {:status "ERROR"})}))
-
 (def get-concepts-for-type-query
   '[:find (pull ?c
                 [:concept/id

--- a/src/clj/jobtech_taxonomy_api/routes/services.clj
+++ b/src/clj/jobtech_taxonomy_api/routes/services.clj
@@ -141,7 +141,14 @@
                       description :- String
                       preferredTerm :- String]
        :summary      "Assert a new concept."
-       {:body (assert-concept type description preferredTerm)})
+       :responses {200 {:schema {:message s/Str :timestamp Date }}
+                   409 {:schema {:message s/Str}}
+                   500 {:schema {:type s/Str, :message s/Str}}}
+       (log/info "POST /concept")
+       (let [[result timestamp] (assert-concept type description preferredTerm)]
+         (if result
+           (response/ok {:timestamp timestamp :message "OK"})
+           (response/conflict { :message "Conflict with existing concept." } ))))
 
      (POST "/replace-concept"    []
        :query-params [old-concept-id :- String

--- a/test/clj/jobtech_taxonomy_api/test/changes_test.clj
+++ b/test/clj/jobtech_taxonomy_api/test/changes_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :as test]
             [jobtech-taxonomy-api.test.test-utils :as util]
             [jobtech-taxonomy-api.db.events :as events]
-            [jobtech-taxonomy-api.db.concept :as concept]
+            [jobtech-taxonomy-api.db.concepts :as concept]
             [jobtech-taxonomy-api.db.core :as core]
             ))
 

--- a/test/clj/jobtech_taxonomy_api/test/changes_test.clj
+++ b/test/clj/jobtech_taxonomy_api/test/changes_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :as test]
             [jobtech-taxonomy-api.test.test-utils :as util]
             [jobtech-taxonomy-api.db.events :as events]
+            [jobtech-taxonomy-api.db.concept :as concept]
             [jobtech-taxonomy-api.db.core :as core]
             ))
 
@@ -9,7 +10,7 @@
 
 (test/deftest ^:integration-changes-test-0 changes-test-0
   (test/testing "test event stream"
-    (core/assert-concept "skill" "cykla" "cykla")
+    (concept/assert-concept "skill" "cykla" "cykla")
     (let [[status body] (util/send-request-to-json-service
                          :get "/v0/taxonomy/public/changes"
                          :headers [util/header-auth-user]
@@ -24,7 +25,7 @@
 
 (test/deftest ^:integration-changes-test-1 changes-test-1
   (test/testing "test event stream"
-    (core/assert-concept "skill2" "cykla2" "cykla2")
+    (concept/assert-concept "skill2" "cykla2" "cykla2")
     (let [[status body] (util/send-request-to-json-service
                          :get "/v0/taxonomy/public/changes"
                          :headers [util/header-auth-user]
@@ -35,4 +36,3 @@
       (test/is (= "CREATED" (:eventType an-event)))
 
       (test/is (= "cykla2" (get found-concept :preferredLabel))))))
-

--- a/test/clj/jobtech_taxonomy_api/test/concepts_test.clj
+++ b/test/clj/jobtech_taxonomy_api/test/concepts_test.clj
@@ -3,13 +3,14 @@
             [jobtech-taxonomy-api.test.test-utils :as util]
             [jobtech-taxonomy-api.db.events :as events]
             [jobtech-taxonomy-api.db.core :as core]
+            [jobtech-taxonomy-api.db.concept :as concept]
             ))
 
 (test/use-fixtures :each util/fixture)
 
 (test/deftest ^:integration-concepts-test-0 concepts-test-0
   (test/testing "test concepts "
-    (core/assert-concept "skill" "cyklade" "cykla")
+    (concept/assert-concept "skill" "cyklade" "cykla")
     (let [[status body] (util/send-request-to-json-service
                           :get "/v0/taxonomy/public/concepts"
                           :headers [util/header-auth-user]
@@ -20,7 +21,7 @@
 
 (test/deftest ^:integration-concepts-test-1 concepts-test-1
   (test/testing "test concepts"
-    (core/assert-concept "skill2" "cyklade" "cykla2")
+    (concept/assert-concept "skill2" "cyklade" "cykla2")
     (let [[status body] (util/send-request-to-json-service
                           :get "/v0/taxonomy/public/concepts"
                           :headers [util/header-auth-user]

--- a/test/clj/jobtech_taxonomy_api/test/concepts_test.clj
+++ b/test/clj/jobtech_taxonomy_api/test/concepts_test.clj
@@ -3,7 +3,7 @@
             [jobtech-taxonomy-api.test.test-utils :as util]
             [jobtech-taxonomy-api.db.events :as events]
             [jobtech-taxonomy-api.db.core :as core]
-            [jobtech-taxonomy-api.db.concept :as concept]
+            [jobtech-taxonomy-api.db.concepts :as concept]
             ))
 
 (test/use-fixtures :each util/fixture)

--- a/test/clj/jobtech_taxonomy_api/test/search_test.clj
+++ b/test/clj/jobtech_taxonomy_api/test/search_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :as test]
             [jobtech-taxonomy-api.test.test-utils :as util]
             [jobtech-taxonomy-api.db.events :as events]
-            [jobtech-taxonomy-api.db.concept :as concept]
+            [jobtech-taxonomy-api.db.concepts :as concept]
             [jobtech-taxonomy-api.db.core :as core]))
 
 (test/use-fixtures :each util/fixture)

--- a/test/clj/jobtech_taxonomy_api/test/search_test.clj
+++ b/test/clj/jobtech_taxonomy_api/test/search_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :as test]
             [jobtech-taxonomy-api.test.test-utils :as util]
             [jobtech-taxonomy-api.db.events :as events]
+            [jobtech-taxonomy-api.db.concept :as concept]
             [jobtech-taxonomy-api.db.core :as core]))
 
 (test/use-fixtures :each util/fixture)
@@ -10,7 +11,7 @@
 
 (test/deftest ^:integration-search-test-0 search-test-0
   (test/testing "test search "
-    (core/assert-concept "skill" "cyklade" "cykla")
+    (concept/assert-concept "skill" "cyklade" "cykla")
     (let [[status body] (util/send-request-to-json-service
                           :get "/v0/taxonomy/public/search"
                           :headers [util/header-auth-user]


### PR DESCRIPTION
Denna buggfix hör till ett kort i Trello - det gick att asserta samma koncept flera gånger och få olika IDn.