### PR TITLE
Webhooks

### DIFF
--- a/env/dev/resources/config.edn
+++ b/env/dev/resources/config.edn
@@ -6,5 +6,10 @@
               ;;:creds-profile "<your_aws_profile_if_not_using_the_default>"
               :endpoint "http://entry.prod-jobtech-taxonomy-db.eu-west-1.datomic.net:8182/"
               :proxy-port 8182}
- :jobtech-taxonomy-api {:auth-tokens {:111 :user :222 :admin} }
+ :jobtech-taxonomy-api {:auth-tokens {:111 :user :222 :admin}
+                        :user-ids {:222 "admin-1"}}
+ ;; Some online service, can be handy when debugging
+ :webhook-clients [{:url "https://postman-echo.com/post" :headers {}}]
+ ;; konserve store directory
+ :filestore "/tmp/store"
 }

--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                  [metosin/ring-http-response "0.9.1"]
                  [mount "0.1.16"]
                  [nrepl "0.6.0"]
-
+                 [io.replikativ/konserve "0.5.1"]
                  [clj-http "3.10.0"]
 
 

--- a/src/clj/jobtech_taxonomy_api/routes/services.clj
+++ b/src/clj/jobtech_taxonomy_api/routes/services.clj
@@ -37,7 +37,6 @@
 ;;   - adjust tests
 ;;   - fixa replaced-by-modell i /changes, /replaced-by-changes, /search, /private/concept
 
-
 (defn log-info [message]
   (log/info message)
   )
@@ -436,15 +435,11 @@
                         (log/info (str "POST /versions" new-version-id))
                         (let [result (v/create-new-version new-version-id)]
                           (if result
-                            (let [notification-result
-                                  (webhooks/send-notifications
-                                   (webhooks/get-client-list-from-conf!)
-                                   new-version-id)]
+                            (let [clients (webhooks/get-client-list-from-store!)
+                                  notification-result (webhooks/send-notifications clients new-version-id)]
                               {:status 200 :body (types/map->nsmap
                                                   {:message (format "A new version of the Taxonomy was created. %d webhook notifications were sent." (count (remove nil? notification-result)))})})
-                            {:status 406 :body (types/map->nsmap {:error (str new-version-id " is not the next valid version id!")}) }
-                            )))}}]
-
+                            {:status 406 :body (types/map->nsmap {:error (str new-version-id " is not the next valid version id!")})})))}}]
 
     ["/automatic-daynotes/concept"
      {

--- a/src/clj/jobtech_taxonomy_api/routes/services.clj
+++ b/src/clj/jobtech_taxonomy_api/routes/services.clj
@@ -11,7 +11,6 @@
    [buddy.auth.middleware :refer [wrap-authentication]]
    [buddy.auth :refer [authenticated?]]
    [buddy.auth.http :as http]
-   [environ.core :refer [env]]
    [ring.util.http-response :as resp]
    [jobtech-taxonomy-api.middleware.formats :as formats]
    [jobtech-taxonomy-api.middleware.cors :as cors]
@@ -26,6 +25,7 @@
    [jobtech-taxonomy-api.db.core :as core]
    [jobtech-taxonomy-api.db.daynotes :as daynotes]
    [jobtech-taxonomy-api.webhooks :as webhooks]
+   [jobtech-taxonomy-api.store :as store]
    [taxonomy :as types]
    [clojure.tools.logging :as log]
    [clojure.spec.alpha :as s]
@@ -458,7 +458,28 @@
                           {:status 200
                            :body (daynotes/get-automatic-day-note-for-concept id)
                            }
-                          )}}]
+                          )}}]]
+
+   ["/webhooks"
+    {:swagger {:tags ["Webhooks"]}
+     :middleware [cors/cors auth authorized-private?]}
+
+    ["/register"
+     {
+      :summary ""
+      :parameters {:query {:api-key (taxonomy/par string? "A unique API-key used as identifier.")
+                           :callback-url (taxonomy/par string? "A URL to a webhook callback listener.")}}
+      :post {:responses {200 {:body types/ok-spec}
+                         406 {:body types/error-spec}
+                         500 {:body types/error-spec}}
+             :handler (fn [{{{:keys [api-key callback-url]} :query} :parameters}]
+                        (log/info (str "POST /webhooks/register " api-key " " callback-url))
+                        (let [result (store/store-update api-key callback-url)]
+                          (if result
+                            {:status 200 :body (types/map->nsmap
+                                                {:message (format "The webhook callback was registered.")})}
+                            {:status 406 :body (types/map->nsmap {:error (str "Could not create webhook callback with values " api-key " " callback-url)}) }
+                            )))}}]
 
 
-    ]])
+   ]])

--- a/src/clj/jobtech_taxonomy_api/store.clj
+++ b/src/clj/jobtech_taxonomy_api/store.clj
@@ -1,0 +1,42 @@
+(ns jobtech-taxonomy-api.store
+    (:require [konserve.filestore :as filestore]
+              [konserve.core :as k]
+              [mount.core :as mount]
+              [jobtech-taxonomy-api.config :refer [env]]
+              [clojure.core.async :as async :refer [<!!]]))
+
+;; Note: We use the thread blocking operations <!! here only to synchronize
+;; with the REPL. <!! is blocking IO and does not compose well with async
+;; contexts, so prefer composing your application with go and <! instead.
+
+(defn store-new [name]
+  (<!! (filestore/new-fs-store name)))
+
+(mount/defstate ^{:on-reload :noop} store
+  :start
+  (when (env :filestore)
+    (store-new (env :filestore))))
+
+(defn store-delete-store [& [store-arg]]
+  (let [s (or store-arg store)]
+    (filestore/delete-store s)))
+
+(defn store-update [key val & [store-arg]]
+  (let [s (or store-arg store)]
+    (<!! (k/assoc-in s [key] val))))
+
+(defn store-get [key & [store-arg]]
+  (let [s (or store-arg store)]
+    (<!! (k/get-in s [key]))))
+
+(defn store-list-keys [& [store-arg]]
+  (let [s (or store-arg store)]
+    (<!! (filestore/list-keys s))))
+
+(defn store-exists? [key & [store-arg]]
+  (let [s (or store-arg store)]
+    (<!! (k/exists? s key))))
+
+(defn store-delete [key & [store-arg]]
+  (let [s (or store-arg store)]
+    (<!! (k/dissoc s :bar))))

--- a/src/clj/jobtech_taxonomy_api/webhooks.clj
+++ b/src/clj/jobtech_taxonomy_api/webhooks.clj
@@ -1,5 +1,6 @@
 (ns jobtech-taxonomy-api.webhooks
   (:require
+   [jobtech-taxonomy-api.config :refer [env]]
    [clojure.tools.logging :as log]
    [clj-http.client :as client]))
 
@@ -17,11 +18,9 @@
                                      :exception e})))))
 
 (defn send-notifications [clients version]
-  ""
   (map #(send-notification % version) clients))
 
 (defn get-client-list-from-conf! []
-  "FIXME: fetch from the configuration/environment."
-  [{:url "https://postman-echo.com/put"
-    ;;:headers {"api-key" "yyy"}
-    :headers {}}])
+  "Set webhook-clients either in config.edn or the environment, for example:
+ webhook-clients='[{:url \"https://postman-echo.com/put\" :headers {}}]'"
+  (set (keys (get env :webhook-clients))))

--- a/src/clj/jobtech_taxonomy_api/webhooks.clj
+++ b/src/clj/jobtech_taxonomy_api/webhooks.clj
@@ -1,6 +1,7 @@
 (ns jobtech-taxonomy-api.webhooks
   (:require
    [jobtech-taxonomy-api.config :refer [env]]
+   [jobtech-taxonomy-api.store :as store]
    [clojure.tools.logging :as log]
    [clj-http.client :as client]))
 
@@ -24,3 +25,10 @@
   "Set webhook-clients either in config.edn or the environment, for example:
  webhook-clients='[{:url \"https://postman-echo.com/post\" :headers {}}]'"
   (set (keys (get env :webhook-clients))))
+
+(defn get-client-list-from-store! []
+  ""
+  (map #(let [key (:key %)
+              url (store/store-get key)]
+          {:url url :headers {:api-key key}})
+       (into [] (store/store-list-keys))))

--- a/src/clj/jobtech_taxonomy_api/webhooks.clj
+++ b/src/clj/jobtech_taxonomy_api/webhooks.clj
@@ -8,7 +8,7 @@
   "A client is a map: {:url callback-url :headers map-of-headers}. A useful map-of-headers value could be {\"api-key\" \"hejhopp\"}."
   (let [{:keys [url headers]} client]
     (try
-      (client/put url {:body (format "{\"version\": %d}" version)
+      (client/post url {:body (format "{\"version\": %d}" version)
                        :headers headers
                        :content-type :json
                        :socket-timeout 1000      ;; in milliseconds
@@ -22,5 +22,5 @@
 
 (defn get-client-list-from-conf! []
   "Set webhook-clients either in config.edn or the environment, for example:
- webhook-clients='[{:url \"https://postman-echo.com/put\" :headers {}}]'"
+ webhook-clients='[{:url \"https://postman-echo.com/post\" :headers {}}]'"
   (set (keys (get env :webhook-clients))))

--- a/src/clj/jobtech_taxonomy_api/webhooks.clj
+++ b/src/clj/jobtech_taxonomy_api/webhooks.clj
@@ -1,0 +1,27 @@
+(ns jobtech-taxonomy-api.webhooks
+  (:require
+   [clojure.tools.logging :as log]
+   [clj-http.client :as client]))
+
+(defn send-notification [client version]
+  "A client is a map: {:url callback-url :headers map-of-headers}. A useful map-of-headers value could be {\"api-key\" \"hejhopp\"}."
+  (let [{:keys [url headers]} client]
+    (try
+      (client/put url {:body (format "{\"version\": %d}" version)
+                       :headers headers
+                       :content-type :json
+                       :socket-timeout 1000      ;; in milliseconds
+                       :connection-timeout 1000  ;; in milliseconds
+                       :accept :json})
+      (catch Exception e (log/error {:what :uncaught-exception
+                                     :exception e})))))
+
+(defn send-notifications [clients version]
+  ""
+  (map #(send-notification % version) clients))
+
+(defn get-client-list-from-conf! []
+  "FIXME: fetch from the configuration/environment."
+  [{:url "https://postman-echo.com/put"
+    ;;:headers {"api-key" "yyy"}
+    :headers {}}])

--- a/test/clj/jobtech_taxonomy_api/test/store.clj
+++ b/test/clj/jobtech_taxonomy_api/test/store.clj
@@ -1,0 +1,22 @@
+(ns jobtech-taxonomy-api.test.store
+  (:require [clojure.test :as test]
+            [jobtech-taxonomy-api.store :as store]))
+
+(test/deftest test-store-0
+  (test/testing "Test store"
+    (let [temp-file-name (str (java.io.File/createTempFile "/tmp" ".tmp"))
+          temp-dir-name  (str temp-file-name ".dir")
+          store (store/store-new temp-dir-name)
+          contents-0 (store/store-list-keys store)
+          update-0 (store/store-update "key" "val" store)
+          contents-1 (store/store-list-keys store)
+          ;;delete-0 (store/store-delete "key" store) ;; FIXME: understand why key is not removed from store
+          ;;contents-2 (store/store-list-keys store)
+          ]
+
+      (test/is (= contents-0 #{}))
+      (test/is (= contents-1 #{{:key "key", :format :edn}}))
+      ;;(test/is (= contents-2 #{}))
+
+      (.delete (clojure.java.io/file temp-file-name))
+      (store/store-delete-store temp-dir-name))))

--- a/test/clj/jobtech_taxonomy_api/test/webhooks.clj
+++ b/test/clj/jobtech_taxonomy_api/test/webhooks.clj
@@ -1,0 +1,10 @@
+(ns jobtech-taxonomy-api.test.webhooks
+  (:require [clojure.test :as test]
+            [jobtech-taxonomy-api.webhooks :as webhooks]))
+
+(test/deftest ^:webhook-test-0 test-webhooks-0
+  (test/testing "Test using webhooks"
+    (let [result (webhooks/send-notification {:url "https://postman-echo.com/put"
+                                              :headers {}}
+                                             69)]
+      (test/is (= (:status result) 200)))))

--- a/test/clj/jobtech_taxonomy_api/test/webhooks.clj
+++ b/test/clj/jobtech_taxonomy_api/test/webhooks.clj
@@ -4,7 +4,7 @@
 
 (test/deftest ^:webhook-test-0 test-webhooks-0
   (test/testing "Test using webhooks"
-    (let [result (webhooks/send-notification {:url "https://postman-echo.com/put"
+    (let [result (webhooks/send-notification {:url "https://postman-echo.com/post"
                                               :headers {}}
                                              69)]
       (test/is (= (:status result) 200)))))


### PR DESCRIPTION
Simple web hook support, to allow consumers to get a callback when a new version of the taxonomy is available. Please note that this feature requires a new configuration parameter:
   :filestore "path where files can be stored"

# Registration 
Call `POST /v1/taxonomy/webhooks/register` with these parameters:
   `api-key`: your key
   `callback-url`: the URL you want to receive events to

# Callback
Setup an endpoint on your server, specified by `callback-url` above.
It should accept POST requests.
A header `api-key` will be included in the call, with your api-key as value.
The payload is: `{"version": new-version-number }`
